### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ documented.
 
 ### Requirements
 
-- python>=3.8
+- python>=3.11
 - [HFST](https://github.com/hfst/hfst)
 - GNU make
 - [poetry](https://python-poetry.org/docs/)


### PR DESCRIPTION
Addresses #35 

Py-elotl requires python version 3.11 minimally. The "Development" section in the readme says "> 3.8", so I've updated it.
